### PR TITLE
Relax lower version bounds on some dependencies

### DIFF
--- a/tdigest-Chart/tdigest-Chart.cabal
+++ b/tdigest-Chart/tdigest-Chart.cabal
@@ -37,16 +37,16 @@ library
 
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups          >=0.18.4   && <0.19
+      semigroups          >=0.18.2   && <0.19
 
   -- other dependencies
   build-depends:
-      base-compat         >=0.10.1   && <0.11
+      base-compat         >=0.9.1    && <0.11
     , colour              >=2.3.3    && <2.4
-    , semigroupoids       >=5.2.2    && <5.3
+    , semigroupoids       >=5.1      && <5.3
     , tdigest             >=0.2      && <0.3
-    , lens                >=4.16.1   && <4.17
-    , Chart               >=1.8.3    && <1.9
+    , lens                >=4.15.1   && <4.17
+    , Chart               >=1.8.1    && <1.9
 
   exposed-modules:
       Graphics.Rendering.Chart.Plot.TDigest

--- a/tdigest/tdigest.cabal
+++ b/tdigest/tdigest.cabal
@@ -46,14 +46,14 @@ library
 
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups          >=0.18.4   && <0.19
+      semigroups          >=0.18.2   && <0.19
 
   -- other dependencies
   build-depends:
-      base-compat         >=0.10.1   && <0.11
+      base-compat         >=0.9.1    && <0.11
     , reducers            >=3.12.2   && <3.13
-    , semigroupoids       >=5.2.2    && <5.3
-    , vector              >=0.12.0.1 && <0.13
+    , semigroupoids       >=5.1      && <5.3
+    , vector              >=0.10.12  && <0.13
     , vector-algorithms   >=0.7.0.1  && <0.8
 
   exposed-modules:


### PR DESCRIPTION
I have a project that still uses GHC 7.10.1 with some old libraries. This PR is to allow tdigest/tdigest-Chart to comiple with that compiler and libs. I've confirmed locally that the following commands worked fine:

```sh
cabal new-configure --constraint='vector==0.10.12.3' --constraint='base-compat==0.9.1' --constraint='semigroupoids==5.1' --constraint='semigroups==0.18.2' --constraint='lens==4.15.1' --constraint='Chart==1.8.1' --constraint='dual-tree==0.2.1.1' --enable-tests
cabal new-test all
```

The constraint for dual-tree is necessary because the latest version doesn't compile with `newtype-generics < 0.5.3`.