### PR TITLE
Add size, valid, validate, and debugPrint for NonEmpty

### DIFF
--- a/tdigest/src/Data/TDigest/Tree/NonEmpty.hs
+++ b/tdigest/src/Data/TDigest/Tree/NonEmpty.hs
@@ -49,6 +49,12 @@ module Data.TDigest.Tree.NonEmpty (
     -- ** CDF
     cdf,
     icdf,
+
+    -- * Debug
+    size,
+    valid,
+    validate,
+    debugPrint,
     ) where
 
 import Prelude ()
@@ -154,6 +160,18 @@ cdf = PP.cdf
 
 tdigest :: (Foldable1 f, KnownNat comp) => f Double -> TDigest comp
 tdigest = TDigest . T.tdigest
+
+size :: TDigest comp -> Int
+size = T.size . unEmpty
+
+valid :: TDigest comp -> Bool
+valid = T.valid . unEmpty
+
+validate :: TDigest comp -> Either String (TDigest comp)
+validate = fmap TDigest . T.validate . unEmpty
+
+debugPrint :: TDigest comp -> IO ()
+debugPrint = T.debugPrint . unEmpty
 
 -- $setup
 -- >>> :set -XDataKinds


### PR DESCRIPTION
I'd like to use the `size` function for non-empty `TDigest`s. Also I thought it would make sense to add `valid`, `validate`, and `debugPrint` as well.